### PR TITLE
Add support for txt field directly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,7 +207,7 @@ How this can be achieved is explained here: https://docs.mongodb.org/manual/.
 	.. code-block:: bash
 
 		$ cd ~/mailingSHARK
-		$ python3.5 main.py --backend pipermail --project-name k3b --mailingurl https://mail.kde.org/pipermail/k3b --output ~/temp
+		$ python3.5 main.py --backend pipermail --project-name k3b --mailing-url https://mail.kde.org/pipermail/k3b --output ~/temp
 
 
 Thats it. The results are explained in the database documentation

--- a/mailingshark/mailingshark.py
+++ b/mailingshark/mailingshark.py
@@ -8,7 +8,8 @@ import tarfile
 import sys
 
 import datetime
-from mongoengine import connect, DoesNotExist
+
+from mongoengine import connect, DoesNotExist, ConnectionFailure
 
 from mailingshark.datacollection.basedatacollector import BaseDataCollector
 from mailingshark.analyzer import ParsedMessage
@@ -67,7 +68,11 @@ class MailingSHARK(object):
         # Connect to mongodb
         uri = create_mongodb_uri_string(cfg.user, cfg.password, cfg.host, cfg.port, cfg.authentication_db,
                                         cfg.ssl_enabled)
-        connect(cfg.database, host=uri)
+
+        try:
+            connect(cfg.database, host=uri)
+        except ConnectionFailure:
+            logger.error("Failed to connect to MongoDB")
 
         # Get the project for which issue data is collected
         try:
@@ -233,7 +238,7 @@ class MailingSHARK(object):
                 with open(path_to_store, 'wb') as f:
                     f.write(s)
 
-            if file_path.endswith('.mbox'):
+            if file_path.endswith('.mbox') or file_path.endswith('.txt'):
                 print(file_path)
                 shutil.move(file_path, os.path.join(output_dir, os.path.basename(file_path)))
 


### PR DESCRIPTION
While running it I figured out that the script will ignore files that are downloaded directly as ".txt". I add a code that moves these files to the folder "ready" so we can add them to the database. 